### PR TITLE
add  __attribute__((weak))  to ISR (WDT_vect)

### DIFF
--- a/LowPower.cpp
+++ b/LowPower.cpp
@@ -1000,11 +1000,12 @@ void	LowPowerClass::powerExtStandby(period_t period, adc_t adc, bod_t bod,
 /*******************************************************************************
 * Name: ISR (WDT_vect)
 * Description: Watchdog Timer interrupt service routine. This routine is 
-*		       required to allow automatic WDIF and WDIE bit clearance in 
-*			   hardware.
+*              required to allow automatic WDIF and WDIE bit clearance in 
+*              hardware. Declared with __attribute__((weak)) to allow
+*              linking in a custom ISR(WDT_vect) if needed.
 *
 *******************************************************************************/
-ISR (WDT_vect)
+ISR (WDT_vect, __attribute__((weak)) )
 {
 	// WDIE & WDIF is cleared in hardware upon entering this ISR
 	wdt_disable();


### PR DESCRIPTION
Attribute the WDT ISR as weak so one can link a custom ISR in case one uses the WDT in other parts of the program for other purposes, e.g.  entropy generation (see https://gist.github.com/endolith/2568571)
Making this ISR weak only affects linking and has no effekt whatsoever if no other ISR code is provided.